### PR TITLE
Use debugPrint instead of print for long log text

### DIFF
--- a/lib/redux_logging.dart
+++ b/lib/redux_logging.dart
@@ -1,5 +1,6 @@
 library redux_logging;
 
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:logging/logging.dart';
 import 'package:redux/redux.dart';
 
@@ -88,7 +89,7 @@ class LoggingMiddleware<State> extends MiddlewareClass<State> {
 
     middleware.logger.onRecord.where((record) {
       return record.loggerName == middleware.logger.name;
-    }).listen(print);
+    }).listen((event) => debugPrint(event.toString()));
 
     return middleware;
   }
@@ -108,11 +109,7 @@ class LoggingMiddleware<State> extends MiddlewareClass<State> {
     dynamic action,
     DateTime timestamp,
   ) {
-    return "{\n" +
-        "  Action: $action,\n" +
-        "  State: $state,\n" +
-        "  Timestamp: ${new DateTime.now()}\n" +
-        "}";
+    return "{\n" + "  Action: $action,\n" + "  State: $state,\n" + "  Timestamp: ${new DateTime.now()}\n" + "}";
   }
 
   @override

--- a/lib/redux_logging.dart
+++ b/lib/redux_logging.dart
@@ -109,7 +109,11 @@ class LoggingMiddleware<State> extends MiddlewareClass<State> {
     dynamic action,
     DateTime timestamp,
   ) {
-    return "{\n" + "  Action: $action,\n" + "  State: $state,\n" + "  Timestamp: ${new DateTime.now()}\n" + "}";
+    return "{\n" +
+        "  Action: $action,\n" +
+        "  State: $state,\n" +
+        "  Timestamp: ${new DateTime.now()}\n" +
+        "}";
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,14 +5,11 @@ homepage: https://github.com/brianegan/redux_logging
 author: Brian Egan <brian@brianegan.com>
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.0.0-dev.28.0 <3.0.0'
 
 dependencies:
-  flutter:
-    sdk: flutter
-
   redux: ">=3.0.0 <4.0.0"
   logging: ">=0.11.3 <0.12.0"
 
 dev_dependencies:
-  test: "any"
+  test: ">=0.12.32+2 <0.13.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,11 +5,14 @@ homepage: https://github.com/brianegan/redux_logging
 author: Brian Egan <brian@brianegan.com>
 
 environment:
-  sdk: '>=2.0.0-dev.28.0 <3.0.0'
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
+  flutter:
+    sdk: flutter
+
   redux: ">=3.0.0 <4.0.0"
   logging: ">=0.11.3 <0.12.0"
 
 dev_dependencies:
-  test: ">=0.12.32+2 <0.13.0"
+  test: "any"


### PR DESCRIPTION
Sometime the log will be too long, we should use debugPrint so it can visible to the user.