### PR TITLE
Lazy evaluation for message in logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.2
+
+  - Lazy evaluation for message in logger
+
 ## 0.3.1
 
   - BugFix: Add docs explaining logging middleware needs to be last in chain

--- a/lib/redux_logging.dart
+++ b/lib/redux_logging.dart
@@ -118,7 +118,7 @@ class LoggingMiddleware<State> extends MiddlewareClass<State> {
   @override
   void call(Store<State> store, dynamic action, NextDispatcher next) {
     next(action);
-    logger.log(level, formatter(store.state, action, new DateTime.now()));
+    logger.log(level, () => formatter(store.state, action, new DateTime.now()));
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: redux_logging
 description: Redux.dart Middleware that prints the latest action & state
-version: 0.3.1
+version: 0.3.2
 homepage: https://github.com/brianegan/redux_logging
 author: Brian Egan <brian@brianegan.com>
 
@@ -12,4 +12,4 @@ dependencies:
   logging: ">=0.11.3 <0.12.0"
 
 dev_dependencies:
-  test: ">=0.12.32+2 <0.13.0"
+  test: ">=0.12.32+2 <1.6.5"


### PR DESCRIPTION
Logger package has comment in code
/// If [message] is a [Function], it will be lazy evaluated. 
I made support lazy evaluation in the LoggingMiddleware class.
Thank you