### PR TITLE
Actually use the timestamp argument in message formatters

### DIFF
--- a/lib/redux_logging.dart
+++ b/lib/redux_logging.dart
@@ -99,7 +99,7 @@ class LoggingMiddleware<State> extends MiddlewareClass<State> {
     dynamic action,
     DateTime timestamp,
   ) {
-    return "{Action: $action, State: $state, ts: ${new DateTime.now()}}";
+    return "{Action: $action, State: $state, ts: $timestamp}";
   }
 
   /// A formatter that puts each attribute on it's own line
@@ -111,7 +111,7 @@ class LoggingMiddleware<State> extends MiddlewareClass<State> {
     return "{\n" +
         "  Action: $action,\n" +
         "  State: $state,\n" +
-        "  Timestamp: ${new DateTime.now()}\n" +
+        "  Timestamp: $timestamp\n" +
         "}";
   }
 


### PR DESCRIPTION
The `timestamp` argument in message formatters is unused. This change uses them instead of calling `DateTime.now`.

Tested with `pub run test`.